### PR TITLE
feat: add gravity nonce

### DIFF
--- a/contracts/Compass.vy
+++ b/contracts/Compass.vy
@@ -96,7 +96,7 @@ def __init__(_compass_id: bytes32, _event_id: uint256, _gravity_nonce:uint256, v
     self.last_checkpoint = new_checkpoint
     self.last_valset_id = valset.valset_id
     self.last_event_id = _event_id
-    self.last_gravity_nonce = _gravity_id
+    self.last_gravity_nonce = _gravity_nonce
     log ValsetUpdated(new_checkpoint, valset.valset_id, _event_id)
 
 # utility function to verify EIP712 signature

--- a/contracts/Compass.vy
+++ b/contracts/Compass.vy
@@ -81,7 +81,7 @@ message_id_used: public(HashMap[uint256, bool])
 # compass_id: unique identifier for compass instance
 # valset: initial validator set
 @external
-def __init__(_compass_id: bytes32, _event_id: uint256, _gravity_id:uint256, valset: Valset):
+def __init__(_compass_id: bytes32, _event_id: uint256, _gravity_nonce:uint256, valset: Valset):
     compass_id = _compass_id
     cumulative_power: uint256 = 0
     i: uint256 = 0

--- a/contracts/Compass.vy
+++ b/contracts/Compass.vy
@@ -218,7 +218,7 @@ def submit_batch(consensus: Consensus, token: address, args: TokenSendArgs, batc
     _event_id: uint256 = unsafe_add(self.last_event_id, 1)
     self.last_event_id = _event_id
     self.last_batch_id[token] = batch_id
-    log BatchSendEvent(token, batch_id, _nonce, event_id)
+    log BatchSendEvent(token, batch_id, _nonce, _event_id)
 
 @external
 def deploy_erc20(_paloma_denom: String[64], _name: String[64], _symbol: String[32], _decimals: uint8, _blueprint: address):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from eth_account.messages import encode_defunct
 
 @pytest.fixture
 def CompassContract(validators, powers):
-    return Compass.deploy(bstring2bytes32(b"ETH_01"), 0, [validators, powers, 0], {"from": accounts[0]})
+    return Compass.deploy(bstring2bytes32(b"ETH_01"), 0, 0, [validators, powers, 0], {"from": accounts[0]})
 
 @pytest.fixture
 def TestERC20Contract():


### PR DESCRIPTION
# Related Github tickets

- https://github.com/VolumeFi/paloma/issues/1620

# Background

Gravity expects atomically incrementing nonces with every event emitted. At the moment, that's not the case, as the emitted `event_id` is shared across different message types. The gravity implementation is a lot more strict that our regular communication channels as in it will **enforce** a `id = id + 1` constraint for every nonce it receives, and will attest to them in order only. This is to ensure correctness of order of funds transferred.

This change will also require an update to Pigeon and possibly Paloma in order to populate the constructor properly.
